### PR TITLE
Support rails5.1 and rails 5.2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -13,3 +13,11 @@ end
 appraise "rails_5_0" do
   gem "rails", "~> 5.0.0"
 end
+
+appraise "rails_5_1" do
+  gem "rails", "~> 5.1.0"
+end
+
+appraise "rails_5_2" do
+  gem "rails", "~> 5.2.0"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,3 @@ gem 'timecop'
 gem 'appraisal'
 gem 'sqlite3'
 gem 'nokogiri'
-
-group :active_record do
-  gem 'sqlite3-ruby', :require => 'sqlite3'
-end

--- a/ae-validates_timeliness.gemspec
+++ b/ae-validates_timeliness.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency(%q<rails>, [">= 4.0", "< 5.1"])
+  s.add_runtime_dependency(%q<rails>, [">= 4.0", "< 5.3"])
   s.add_runtime_dependency(%q<timeliness>, ["~> 0.3.7"])
 
   s.add_development_dependency "coveralls"

--- a/gemfiles/rails_4_0.gemfile
+++ b/gemfiles/rails_4_0.gemfile
@@ -8,8 +8,4 @@ gem "appraisal"
 gem "sqlite3"
 gem "nokogiri"
 
-group :active_record do
-  gem "sqlite3-ruby", :require => "sqlite3"
-end
-
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -8,8 +8,4 @@ gem "appraisal"
 gem "sqlite3"
 gem "nokogiri"
 
-group :active_record do
-  gem "sqlite3-ruby", :require => "sqlite3"
-end
-
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -8,8 +8,4 @@ gem "appraisal"
 gem "sqlite3"
 gem "nokogiri"
 
-group :active_record do
-  gem "sqlite3-ruby", :require => "sqlite3"
-end
-
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -2,7 +2,7 @@
 
 source "http://rubygems.org"
 
-gem "rails", "~> 4.1.0"
+gem "rails", "~> 5.1.0"
 gem "timecop"
 gem "appraisal"
 gem "sqlite3"

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -2,7 +2,7 @@
 
 source "http://rubygems.org"
 
-gem "rails", "~> 4.1.0"
+gem "rails", "~> 5.2.0"
 gem "timecop"
 gem "appraisal"
 gem "sqlite3"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,6 +69,9 @@ I18n.enforce_available_locales = false
 
 ActiveRecord::Base.default_timezone = :utc
 ActiveRecord::Base.time_zone_aware_attributes = true
+if ActiveRecord.version >= Gem::Version.new('5')
+  ActiveRecord::Base.time_zone_aware_types = [:datetime]
+end
 ActiveRecord::Base.establish_connection({:adapter => 'sqlite3', :database => ':memory:'})
 ActiveRecord::Migration.verbose = false
 ActiveRecord::Schema.define(:version => 1) do


### PR DESCRIPTION
fix `active_record.time_zone_aware_types` error happen in 5.1 and 5.2

```
DEPRECATION WARNING: Time columns will become time zone aware in Rails 5.1. This still causes `String`s to be parsed as if they were in `Time.zone`, and `Time`s to be converted to `Time.zone`.

To keep the old behavior, you must add the following to your initializer:

    config.active_record.time_zone_aware_types = [:datetime]

To silence this deprecation warning, add the following:

    config.active_record.time_zone_aware_types = [:datetime, :time]
```

What does this even mean? I found an article explain it well http://engineering.liefery.com/2017/10/25/times-in-rails-5.html
Here is a quick summary:

```
Here’s a good way of thinking about it: which columns in your application should return an ActiveSupport::TimeWithZone object?

To keep the old behaviour and only have datetime columns return an ActiveSupport::TimeWithZone object, use [:datetime].
To use the new behaviour and have time columns also return an ActiveSupport::TimeWithZone object, use [:datetime, :time].
```
Here is where I found how to config it without `Rails.config` http://api.rubyonrails.org/classes/ActiveRecord/Timestamp.html

As the testcases suggest, it expects the old behaviour, i.e. only `datetime` is time zone aware.
https://github.com/appfolio/validates_timeliness/blob/4c80b403e500f36ca3d0d93cf312c0a30828b71c/spec/validates_timeliness/orm/active_record_spec.rb#L90-L105

I changed `spec_helper.rb` to set `time_zone_aware_types`, but I don't know how to enforce it in a Rails app. I am not familiar with gem and I am afraid this may break sth 😞 